### PR TITLE
Downgrade FluentAssertions to v7.1.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,9 @@
 {
-    "extends": ["github>project-origin/.github:renovate-defaults.json"]
+    "extends": ["github>project-origin/.github:renovate-defaults.json"],
+    "packageRules": [
+        {
+            "matchPackageNames": ["FluentAssertions"],
+            "allowedVersions": "<=7.1.0"
+        }
+    ]
 }

--- a/test/ProjectOrigin.HierarchicalDeterministicKeys.Tests/ProjectOrigin.HierarchicalDeterministicKeys.Tests.csproj
+++ b/test/ProjectOrigin.HierarchicalDeterministicKeys.Tests/ProjectOrigin.HierarchicalDeterministicKeys.Tests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="FluentAssertions" Version="8.0.1" />
+    <PackageReference Include="FluentAssertions" Version="[7.1.0]" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
- Downgrade FluentAssertions v7.1.0 as versions 8.x.x, are not open source licensed
- Make sure renovate-bot, does not auto-update FluentAssertions beyond 7.1.0, by locking it in the renovate.json config file